### PR TITLE
Use `CURLOPT_CONNECT_TO` instead of `CURLOPT_RESOLVE` and `CURLOPT_PORT`

### DIFF
--- a/example_remote_http.php
+++ b/example_remote_http.php
@@ -32,19 +32,18 @@ $soip_constant_name = "PANTHEON_SOIP_YOUR_SERVICE_NAME";
 print "Through the stunnel, hit the remote service\n";
 print "\n port : " . constant($soip_constant_name);
 
-// Create a "resolve_host" that will point to localhost and resolve externally
+// Create a "connect_to" array that will tell libcurl how to send this request through our tunnel
 $host = parse_url($url, PHP_URL_HOST);
-$localhost = "127.0.0.1";
-$resolve_host = array(sprintf("%s:%d:%s", $host, constant($soip_constant_name), $localhost));
-print "\n resolve_host : " . implode($resolve_host);
+$connect_to = array(sprintf("%s:443:127.0.0.1:%d", $host, constant($soip_constant_name)));
+print "\n connect_to : " . implode($connect_to);
 
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, $url);
-curl_setopt($ch, CURLOPT_RESOLVE, $resolve_host);
-curl_setopt($ch, CURLOPT_PORT, constant($soip_constant_name));
+curl_setopt($ch, CURLOPT_CONNECT_TO, $connect_to);
 curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
 curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 curl_setopt($ch, CURLOPT_VERBOSE, true);
 $start = microtime(true);


### PR DESCRIPTION
The curl option `CURLOPT_CONNECT_TO` was added in libcurl 7.49.0, and we currently have libcurl 7.61.1 in the new COE environments. More info: https://curl.haxx.se/libcurl/c/CURLOPT_CONNECT_TO.html

So on COE, using `CURLOPT_CONNECT_TO` is more correct than using `CURLOPT_RESOLVE`, which is just meant for prepopulating the DNS cache.

Also, explicitly enable `CURLOPT_SSL_VERIFYHOST` even though it defaults to enabled.